### PR TITLE
Fix pagination HTML

### DIFF
--- a/chiminey/simpleui/templates/list_jobs.html
+++ b/chiminey/simpleui/templates/list_jobs.html
@@ -140,7 +140,7 @@ $(document).on('click','.delete', function(e) {
     <ul>
 
         {% if offset <= 0  %}
-        <li class="disabled">&laquo</span></li>
+        <li class="disabled"><span>&laquo</span></li>
         {% else %}
         <li><a href='{% url "hrmcjob-list" %}?offset={{ offset|add:"-20"}}'>&laquo;</a></li>
         {% endif %}


### PR DESCRIPTION
Adds the missing opening tag for the span element.

Before:
![screen shot 2018-07-17 at 4 48 08 pm](https://user-images.githubusercontent.com/41028207/42800999-3c6d1ffa-89e1-11e8-9f1e-fb4f8bfc1091.png)

After:
![screen shot 2018-07-17 at 4 47 55 pm](https://user-images.githubusercontent.com/41028207/42801004-43096c88-89e1-11e8-8066-baa27a338ec8.png)
